### PR TITLE
[bug-fix] dispatch non-paired responseIdentity for integration with other extensions

### DIFF
--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
@@ -722,12 +722,34 @@ internal class AnalyticsExtension(extensionApi: ExtensionApi) : Extension(extens
     private fun publishAnalyticsId(event: Event) {
         val data = getSharedState()
         api.createSharedState(data, event)
-        val responseEvent = Event.Builder(
+
+        // dispatch paired response event, usually used for getters
+        val pairedResponseEvent = Event.Builder(
             "TrackingIdentifierValue",
             EventType.ANALYTICS,
             EventSource.RESPONSE_IDENTITY
         ).setEventData(data).inResponseToEvent(event).build()
+        api.dispatch(pairedResponseEvent)
+        Log.trace(
+            AnalyticsConstants.LOG_TAG,
+            CLASS_NAME,
+            "Dispatching Analytics paired response identity event with eventdata: %s.",
+            data
+        )
+
+        // dispatch regular response event, usually listened by other extensions
+        val responseEvent = Event.Builder(
+            "TrackingIdentifierValue",
+            EventType.ANALYTICS,
+            EventSource.RESPONSE_IDENTITY
+        ).setEventData(data).build()
         api.dispatch(responseEvent)
+        Log.trace(
+            AnalyticsConstants.LOG_TAG,
+            CLASS_NAME,
+            "Dispatching Analytics unpaired response identity event with eventdata: %s.",
+            data
+        )
     }
 
     private fun updateAnalyticsState(event: Event, dependencies: List<String>) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The extension should dispatch a paired Analytics ResponseIdentity (in response to the request event) and a regular ResponseIdentity event for other extensions that integrate with Analytics, such as Identity. The paired events are usually used for getter APIs and they are not visible to regular extension listeners.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
