### PR TITLE
Updates initial shared state onRegistered (resolves #41)

### DIFF
--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsIDTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsIDTests.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.analytics.function.test
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.MobilePrivacyStatus
 import com.adobe.marketing.mobile.analytics.internal.TimeZoneHelper
 import com.adobe.marketing.mobile.analytics.internal.extractContextDataFrom
 import com.adobe.marketing.mobile.analytics.internal.extractQueryParamsFrom
@@ -44,16 +45,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             mapOf(
                 "mid" to "mid",
                 "blob" to "blob",
@@ -138,16 +130,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 countDownLatch.countDown()
             }
         }
-        val configuration = mapOf(
-            "analytics.server" to "test.com",
-            "analytics.rsids" to "rsid",
-            "global.privacy" to "optedin",
-            "experienceCloud.org" to "orgid",
-            "analytics.batchLimit" to 0,
-            "analytics.offlineEnabled" to true,
-            "analytics.backdatePreviousSessionInfo" to true,
-            "analytics.launchHitDelay" to 1
-        )
+        val configuration = config(MobilePrivacyStatus.OPT_IN)
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
             configuration,
             mapOf(
@@ -225,16 +208,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 data?.let { analyticsSharedState = it }
                 countDownLatch.countDown()
             }
-        val configuration = mapOf(
-            "analytics.server" to "test.com",
-            "analytics.rsids" to "rsid",
-            "global.privacy" to "optedout",
-            "experienceCloud.org" to "orgid",
-            "analytics.batchLimit" to 0,
-            "analytics.offlineEnabled" to true,
-            "analytics.backdatePreviousSessionInfo" to true,
-            "analytics.launchHitDelay" to 1
-        )
+        val configuration = config(MobilePrivacyStatus.OPT_OUT)
 
         val configurationResponseEvent = Event.Builder(
             "configuration event",
@@ -299,16 +273,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
             }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             mapOf(
                 "mid" to "mid",
                 "blob" to "blob",
@@ -348,16 +313,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 data?.let { analyticsSharedState = it }
                 countDownLatch.countDown()
             }
-        val configuration = mapOf(
-            "analytics.server" to "test.com",
-            "analytics.rsids" to "rsid",
-            "global.privacy" to "optedout",
-            "experienceCloud.org" to "orgid",
-            "analytics.batchLimit" to 0,
-            "analytics.offlineEnabled" to true,
-            "analytics.backdatePreviousSessionInfo" to true,
-            "analytics.launchHitDelay" to 1
-        )
+        val configuration = config(MobilePrivacyStatus.OPT_OUT)
 
         val configurationResponseEvent = Event.Builder(
             "configuration event",
@@ -450,16 +406,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 countDownLatch.countDown()
             }
 
-        val configuration = mapOf(
-            "analytics.server" to "test.com",
-            "analytics.rsids" to "rsid",
-            "global.privacy" to "optedin",
-            "experienceCloud.org" to "orgid",
-            "analytics.batchLimit" to 0,
-            "analytics.offlineEnabled" to true,
-            "analytics.backdatePreviousSessionInfo" to true,
-            "analytics.launchHitDelay" to 1
-        )
+        val configuration = config(MobilePrivacyStatus.OPT_IN)
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
             configuration,
             mapOf(
@@ -478,16 +425,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
         analyticsExtension.handleIncomingEvent(configurationResponseEvent)
         updateMockedSharedState(
             "com.adobe.module.configuration",
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedout",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            )
+            config(MobilePrivacyStatus.OPT_OUT)
         )
         analyticsExtension.handleIncomingEvent(
             Event.Builder(
@@ -569,16 +507,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 countDownLatch.countDown()
             }
 
-        val configuration = mapOf(
-            "analytics.server" to "test.com",
-            "analytics.rsids" to "rsid",
-            "global.privacy" to "optedin",
-            "experienceCloud.org" to "orgid",
-            "analytics.batchLimit" to 0,
-            "analytics.offlineEnabled" to true,
-            "analytics.backdatePreviousSessionInfo" to true,
-            "analytics.launchHitDelay" to 1
-        )
+        val configuration = config(MobilePrivacyStatus.OPT_IN)
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
             configuration,
             mapOf(
@@ -612,5 +541,18 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
             analyticsSharedState1
         )
         assertTrue(analyticsSharedState2.isEmpty())
+    }
+
+    private fun config(privacyStatus: MobilePrivacyStatus): Map<String, Any> {
+        return mapOf(
+            "analytics.server" to "test.com",
+            "analytics.rsids" to "rsid",
+            "global.privacy" to privacyStatus.value,
+            "experienceCloud.org" to "orgid",
+            "analytics.batchLimit" to 0,
+            "analytics.offlineEnabled" to true,
+            "analytics.backdatePreviousSessionInfo" to true,
+            "analytics.launchHitDelay" to 1
+        )
     }
 }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsIDTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsIDTests.kt
@@ -15,10 +15,10 @@ import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.MobilePrivacyStatus
+import com.adobe.marketing.mobile.analytics.internal.AnalyticsHit
 import com.adobe.marketing.mobile.analytics.internal.TimeZoneHelper
 import com.adobe.marketing.mobile.analytics.internal.extractContextDataFrom
 import com.adobe.marketing.mobile.analytics.internal.extractQueryParamsFrom
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -33,19 +33,7 @@ import java.util.concurrent.CountDownLatch
 internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
 
     @Test(timeout = 10000)
-    fun `hit contains vid vars`() {
-        val countDownLatch = CountDownLatch(1)
-        var varMap: Map<String, Any> = emptyMap()
-        var contextDataMap: Map<String, Any> = emptyMap()
-        monitorNetwork { request ->
-            if (request.url.startsWith("https://test.com/b/ss/rsid/0/")) {
-                val body = URLDecoder.decode(String(request.body), "UTF-8")
-                varMap = extractQueryParamsFrom(body)
-                contextDataMap = extractContextDataFrom(body)
-                countDownLatch.countDown()
-            }
-        }
-
+    fun `handleGenericTrackEvent - hit contains vid vars`() {
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
             config(MobilePrivacyStatus.OPT_IN),
             mapOf(
@@ -71,7 +59,13 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
-        countDownLatch.await()
+        assertEquals(1, mockedMainDataQueue.count())
+
+        val hit = AnalyticsHit.from(mockedMainDataQueue.peek())
+        val body = URLDecoder.decode(hit.payload, "UTF-8")
+        val varMap: Map<String, Any> = extractQueryParamsFrom(body)
+        val contextDataMap: Map<String, Any> = extractContextDataFrom(body)
+
         val expectedVars: Map<String, String> = mapOf(
             "ndh" to "1",
             "ce" to "UTF-8",
@@ -90,13 +84,13 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
             "k2" to "v2",
             "a.action" to "testActionName"
         )
-        Assert.assertTrue(expectedContextData == contextDataMap)
-        Assert.assertEquals(expectedVars.size, varMap.size)
-        Assert.assertEquals(expectedVars, varMap)
+        assertEquals(expectedContextData, contextDataMap)
+        assertEquals(expectedVars.size, varMap.size)
+        assertEquals(expectedVars, varMap)
     }
 
     @Test(timeout = 10000)
-    fun `hit contains vid and aid`() {
+    fun `handleGenericTrackEvent - hit contains vid and aid`() {
         Mockito.`when`(mockedNameCollection.getString(any(), anyOrNull()))
             .thenAnswer { invocation ->
                 when (invocation.arguments[0] as? String) {
@@ -112,26 +106,6 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 }
             }
 
-        val countDownLatch = CountDownLatch(2)
-        var analyticsSharedState: Map<String, Any> = emptyMap()
-
-        Mockito.`when`(mockedExtensionApi.createSharedState(any(), anyOrNull()))
-            .then { invocation ->
-                val data = invocation.arguments[0] as? Map<String, Any>
-                data?.let { analyticsSharedState = it }
-                countDownLatch.countDown()
-            }
-
-        var varMap: Map<String, Any> = emptyMap()
-        var contextDataMap: Map<String, Any> = emptyMap()
-        monitorNetwork { request ->
-            if (request.url.startsWith("https://test.com/b/ss/rsid/0/")) {
-                val body = URLDecoder.decode(String(request.body), "UTF-8")
-                varMap = extractQueryParamsFrom(body)
-                contextDataMap = extractContextDataFrom(body)
-                countDownLatch.countDown()
-            }
-        }
         val configuration = config(MobilePrivacyStatus.OPT_IN)
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
             configuration,
@@ -141,14 +115,6 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 "locationhint" to "lochint"
             )
         )
-
-        val configurationResponseEvent = Event.Builder(
-            "configuration event",
-            EventType.CONFIGURATION,
-            EventSource.RESPONSE_CONTENT
-        ).setEventData(configuration).build()
-
-        analyticsExtension.handleIncomingEvent(configurationResponseEvent)
 
         val trackEvent = Event.Builder(
             "track event",
@@ -166,7 +132,13 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
-        countDownLatch.await()
+        assertEquals(1, mockedMainDataQueue.count())
+
+        val hit = AnalyticsHit.from(mockedMainDataQueue.peek())
+        val body = URLDecoder.decode(hit.payload, "UTF-8")
+        val varMap: Map<String, Any> = extractQueryParamsFrom(body)
+        val contextDataMap: Map<String, Any> = extractContextDataFrom(body)
+
         val expectedVars: Map<String, String> = mapOf(
             "ndh" to "1",
             "ce" to "UTF-8",
@@ -187,16 +159,9 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
             "k2" to "v2",
             "a.action" to "testActionName"
         )
-        assertTrue(expectedContextData == contextDataMap)
+        assertEquals(expectedContextData, contextDataMap)
         assertEquals(expectedVars.size, varMap.size)
         assertEquals(expectedVars, varMap)
-        assertEquals(
-            mapOf(
-                "aid" to "testaid",
-                "vid" to "testvid"
-            ),
-            analyticsSharedState
-        )
     }
 
     @Test(timeout = 10000)
@@ -305,8 +270,8 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
     }
 
     @Test(timeout = 10000)
-    fun `handleAnalyticsRequestIdentityEvent - shared state not should contain vid if optedout`() {
-        val countDownLatch = CountDownLatch(2)
+    fun `handleAnalyticsRequestIdentityEvent - shared state should not contain vid if optedout`() {
+        val countDownLatch = CountDownLatch(1)
         var analyticsSharedState: Map<String, Any> = emptyMap()
 
         Mockito.`when`(mockedExtensionApi.createSharedState(any(), anyOrNull()))
@@ -504,19 +469,14 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
                 }
             }
 
-        val countDownLatch = CountDownLatch(2)
+        val countDownLatch = CountDownLatch(1)
         var analyticsSharedState1: Map<String, Any> = emptyMap()
-        var analyticsSharedState2: Map<String, Any> = emptyMap()
 
         Mockito.`when`(mockedExtensionApi.createSharedState(any(), anyOrNull()))
             .then { invocation ->
                 val data = invocation.arguments[0] as? Map<String, Any>
                 data?.let {
-                    if (analyticsSharedState1.isEmpty()) {
-                        analyticsSharedState1 = it
-                    } else {
-                        analyticsSharedState2 = it
-                    }
+                    analyticsSharedState1 = it
                 }
                 countDownLatch.countDown()
             }
@@ -547,14 +507,7 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
         )
 
         countDownLatch.await()
-        assertEquals(
-            mapOf(
-                "aid" to "testaid",
-                "vid" to "testvid"
-            ),
-            analyticsSharedState1
-        )
-        assertTrue(analyticsSharedState2.isEmpty())
+        assertTrue(analyticsSharedState1.isEmpty())
     }
 
     private fun config(privacyStatus: MobilePrivacyStatus): Map<String, Any> {

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtensionTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtensionTests.kt
@@ -80,13 +80,23 @@ class AnalyticsExtensionTests {
     }
 
     @Test
-    fun `onRegistered() should call createSharedState for version 0`() {
+    fun `onRegistered() when aid, vid should createSharedState with ids for version 0`() {
         `when`(mockNamedCollection.getString(any(), any())).thenReturn("test")
         ExtensionHelper.notifyRegistered(analytics)
 
         val expectedData = mutableMapOf<String, Any>()
         expectedData["aid"] = "test"
         expectedData["vid"] = "test"
+
+        verify(mockApi).createSharedState(eq(expectedData), eq(null))
+    }
+
+    @Test
+    fun `onRegistered() when no aid, vid should createSharedState with empty data for version 0`() {
+        `when`(mockNamedCollection.getString(any(), any())).thenReturn(null)
+        ExtensionHelper.notifyRegistered(analytics)
+
+        val expectedData = emptyMap<String, Any>()
 
         verify(mockApi).createSharedState(eq(expectedData), eq(null))
     }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtensionTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtensionTests.kt
@@ -1,0 +1,162 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.analytics.internal
+
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.ExtensionApi
+import com.adobe.marketing.mobile.ExtensionEventListener
+import com.adobe.marketing.mobile.ExtensionHelper
+import com.adobe.marketing.mobile.services.DataStoring
+import com.adobe.marketing.mobile.services.NamedCollection
+import com.adobe.marketing.mobile.services.ServiceProvider
+import com.adobe.marketing.mobile.util.SQLiteUtils
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.eq
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class AnalyticsExtensionTests {
+    private lateinit var analytics: AnalyticsExtension
+
+    @Mock
+    private lateinit var mockApi: ExtensionApi
+
+    @Mock
+    private lateinit var mockDataStore: DataStoring
+
+    @Mock
+    private lateinit var mockNamedCollection: NamedCollection
+
+    @Mock
+    private lateinit var mockDatabase: AnalyticsDatabase
+
+    @Mock
+    private lateinit var mockServiceProvider: ServiceProvider
+
+    private val mockedStaticServiceProvider = mockStatic(
+        ServiceProvider::class.java
+    )
+
+    @Before
+    fun setup() {
+        mockedStaticServiceProvider.`when`<Any> { ServiceProvider.getInstance() }
+            .thenReturn(mockServiceProvider)
+        `when`(mockDataStore.getNamedCollection(eq("AnalyticsDataStorage"))).thenReturn(mockNamedCollection)
+        `when`(mockServiceProvider.dataStoreService).thenReturn(mockDataStore)
+        analytics = AnalyticsExtension(mockApi, mockDatabase)
+    }
+
+    @After
+    fun tearDown() {
+        reset(mockApi)
+        reset(mockDataStore)
+        reset(mockDatabase)
+        reset(mockNamedCollection)
+        mockedStaticServiceProvider.close()
+        reset(mockServiceProvider)
+    }
+
+    @Test
+    fun `onRegistered() should call createSharedState for version 0`() {
+        `when`(mockNamedCollection.getString(any(), any())).thenReturn("test")
+        ExtensionHelper.notifyRegistered(analytics)
+
+        val expectedData = mutableMapOf<String, Any>()
+        expectedData["aid"] = "test"
+        expectedData["vid"] = "test"
+
+        verify(mockApi).createSharedState(eq(expectedData), eq(null))
+    }
+
+    @Test
+    fun `onRegistered() should register correct listeners`() {
+        ExtensionHelper.notifyRegistered(analytics)
+
+        val eventTypeCaptor = ArgumentCaptor.forClass(String::class.java)
+        val eventSourceCaptor = ArgumentCaptor.forClass(String::class.java)
+        val listenerCaptor = ArgumentCaptor.forClass(ExtensionEventListener::class.java)
+
+        verify(mockApi, times(9)).registerEventListener(
+            eventTypeCaptor.capture(),
+            eventSourceCaptor.capture(),
+            listenerCaptor.capture()
+        )
+
+        assertEquals(EventType.RULES_ENGINE, eventTypeCaptor.allValues[0])
+        assertEquals(EventSource.RESPONSE_CONTENT, eventSourceCaptor.allValues[0])
+        assertNotNull(listenerCaptor.allValues[0])
+
+        assertEquals(EventType.ANALYTICS, eventTypeCaptor.allValues[1])
+        assertEquals(EventSource.REQUEST_CONTENT, eventSourceCaptor.allValues[1])
+        assertNotNull(listenerCaptor.allValues[1])
+
+        assertEquals(EventType.ANALYTICS, eventTypeCaptor.allValues[2])
+        assertEquals(EventSource.REQUEST_IDENTITY, eventSourceCaptor.allValues[2])
+        assertNotNull(listenerCaptor.allValues[2])
+
+        assertEquals(EventType.CONFIGURATION, eventTypeCaptor.allValues[3])
+        assertEquals(EventSource.RESPONSE_CONTENT, eventSourceCaptor.allValues[3])
+        assertNotNull(listenerCaptor.allValues[3])
+
+        assertEquals(EventType.GENERIC_LIFECYCLE, eventTypeCaptor.allValues[4])
+        assertEquals(EventSource.REQUEST_CONTENT, eventSourceCaptor.allValues[4])
+        assertNotNull(listenerCaptor.allValues[4])
+
+        assertEquals(EventType.LIFECYCLE, eventTypeCaptor.allValues[5])
+        assertEquals(EventSource.RESPONSE_CONTENT, eventSourceCaptor.allValues[5])
+        assertNotNull(listenerCaptor.allValues[5])
+
+        assertEquals(EventType.ACQUISITION, eventTypeCaptor.allValues[6])
+        assertEquals(EventSource.RESPONSE_CONTENT, eventSourceCaptor.allValues[6])
+        assertNotNull(listenerCaptor.allValues[6])
+
+        assertEquals(EventType.GENERIC_TRACK, eventTypeCaptor.allValues[7])
+        assertEquals(EventSource.REQUEST_CONTENT, eventSourceCaptor.allValues[7])
+        assertNotNull(listenerCaptor.allValues[7])
+
+        assertEquals(EventType.GENERIC_IDENTITY, eventTypeCaptor.allValues[8])
+        assertEquals(EventSource.REQUEST_RESET, eventSourceCaptor.allValues[8])
+        assertNotNull(listenerCaptor.allValues[8])
+    }
+
+    @Test
+    fun `onRegistered() should delete deprecated hit database file`() {
+        mockStatic(SQLiteUtils::class.java).use { sqliteUtilsMockedStatic ->
+            val fileNameClassCaptor =
+                ArgumentCaptor.forClass(
+                    String::class.java
+                )
+            sqliteUtilsMockedStatic
+                .`when`<Any> {
+                    SQLiteUtils.deleteDBFromCacheDir(fileNameClassCaptor.capture())
+                }
+                .thenReturn(true)
+            ExtensionHelper.notifyRegistered(analytics)
+
+            assertEquals("ADBMobileDataCache.sqlite", fileNameClassCaptor.value)
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Decoupled the boot up from the config response event and Analytics shared state with previously cached values. Config response events will now post the updated shared state only on privacy optout (clearing the ids) - this is also in line with 1.x.
- Updated few unrelated tests that were assuming the first config event will share initial state

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
