### PR TITLE
Increase code coverage to 90% (resolves #42)

### DIFF
--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsConstants.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsConstants.kt
@@ -165,6 +165,12 @@ internal object AnalyticsConstants {
             const val VISITOR_ID_LOCATION_HINT = "locationhint"
             const val VISITOR_IDS_LIST = "visitoridslist"
             const val ADVERTISING_IDENTIFIER = "advertisingidentifier"
+
+            internal object VisitorID {
+                const val ID = "ID"
+                const val ID_TYPE = "ID_TYPE"
+                const val STATE = "STATE"
+            }
         }
 
         internal object Lifecycle {

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
@@ -221,7 +221,8 @@ internal class AnalyticsExtension : Extension {
      * @see AnalyticsState.resetIdentities
      * @see AnalyticsDatabase.reset
      */
-    private fun handleResetIdentitiesEvent(event: Event) {
+    @VisibleForTesting
+    internal fun handleResetIdentitiesEvent(event: Event) {
         if (event.type != EventType.GENERIC_IDENTITY || event.source != EventSource.REQUEST_RESET) {
             Log.debug(
                 AnalyticsConstants.LOG_TAG,
@@ -398,7 +399,8 @@ internal class AnalyticsExtension : Extension {
      *
      * @param event the generic lifecycle request content event
      */
-    private fun handleGenericLifecycleEvents(event: Event) {
+    @VisibleForTesting
+    internal fun handleGenericLifecycleEvents(event: Event) {
         if (event.type != EventType.GENERIC_LIFECYCLE || event.source != EventSource.REQUEST_CONTENT) {
             return
         }

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
@@ -271,7 +271,8 @@ internal class AnalyticsExtension : Extension {
      *
      * @param event the rules engine response content event
      */
-    private fun handleRuleEngineResponse(event: Event) {
+    @VisibleForTesting
+    internal fun handleRuleEngineResponse(event: Event) {
         val eventData = event.eventData ?: run {
             Log.trace(
                 AnalyticsConstants.LOG_TAG,

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
@@ -23,7 +23,7 @@ import java.util.HashMap
  * The [AnalyticsState] class will encapsulate the analytics config properties used across the analytics handlers,
  * which are retrieved from SharedState.
  */
-internal class AnalyticsState {
+class AnalyticsState {
     internal var host: String? = null
         private set
 
@@ -75,7 +75,7 @@ internal class AnalyticsState {
     internal var lifecycleSessionStartTimestamp: Long = 0
         private set
 
-    internal fun update(dataMap: Map<String, Map<String, Any>?>) {
+    internal fun update(dataMap: Map<String, Map<String, Any?>?>) {
         for ((key, value) in dataMap) {
             if (value == null) {
                 Log.trace(

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
@@ -79,6 +79,12 @@ internal class AnalyticsState {
     internal fun update(dataMap: Map<String, Map<String, Any>?>) {
         for ((key, value) in dataMap) {
             if (value == null) {
+                Log.trace(
+                    AnalyticsConstants.LOG_TAG,
+                    LOG_TAG,
+                    "update - Unable to extract data for %s, it was null.",
+                    key
+                )
                 continue
             }
             when (key) {
@@ -106,15 +112,7 @@ internal class AnalyticsState {
      *
      * @param configuration the eventData map from Config's shared state
      */
-    private fun extractConfigurationInfo(configuration: Map<String, Any?>?) {
-        if (configuration == null) {
-            Log.trace(
-                AnalyticsConstants.LOG_TAG,
-                LOG_TAG,
-                "extractConfigurationInfo - Failed to extract configuration data as event data was null."
-            )
-            return
-        }
+    private fun extractConfigurationInfo(configuration: Map<String, Any?>) {
         host = DataReader.optString(
             configuration,
             AnalyticsConstants.EventDataKeys.Configuration.ANALYTICS_CONFIG_SERVER,
@@ -177,15 +175,7 @@ internal class AnalyticsState {
      *
      * @param identityInfo the eventData map from Identity's shared state
      */
-    private fun extractIdentityInfo(identityInfo: Map<String, Any?>?) {
-        if (identityInfo == null) {
-            Log.trace(
-                AnalyticsConstants.LOG_TAG,
-                LOG_TAG,
-                "extractIdentityInfo - Failed to extract identity data as event data was null."
-            )
-            return
-        }
+    private fun extractIdentityInfo(identityInfo: Map<String, Any?>) {
         marketingCloudId = DataReader.optString(
             identityInfo,
             AnalyticsConstants.EventDataKeys.Identity.VISITOR_ID_MID,
@@ -232,15 +222,7 @@ internal class AnalyticsState {
      *
      * @param placesInfo the eventData map from Places shared state
      */
-    private fun extractPlacesInfo(placesInfo: Map<String, Any?>?) {
-        if (placesInfo == null) {
-            Log.trace(
-                AnalyticsConstants.LOG_TAG,
-                LOG_TAG,
-                "extractPlacesInfo - Failed to extract places data (event data was null)."
-            )
-            return
-        }
+    private fun extractPlacesInfo(placesInfo: Map<String, Any?>) {
         val placesContextData = DataReader.optTypedMap(
             String::class.java,
             placesInfo,
@@ -264,15 +246,7 @@ internal class AnalyticsState {
      *
      * @param lifecycleData the eventData map from Lifecycle's shared state
      */
-    private fun extractLifecycleInfo(lifecycleData: Map<String, Any?>?) {
-        if (lifecycleData == null) {
-            Log.trace(
-                AnalyticsConstants.LOG_TAG,
-                LOG_TAG,
-                "extractLifecycleInfo - Failed to extract lifecycle data (event data was null)."
-            )
-            return
-        }
+    private fun extractLifecycleInfo(lifecycleData: Map<String, Any?>) {
         lifecycleSessionStartTimestamp = DataReader.optLong(
             lifecycleData,
             AnalyticsConstants.EventDataKeys.Lifecycle.SESSION_START_TIMESTAMP,
@@ -331,15 +305,7 @@ internal class AnalyticsState {
      *
      * @param assuranceInfo the eventData map from Assurance's shared state
      */
-    private fun extractAssuranceInfo(assuranceInfo: Map<String, Any?>?) {
-        if (assuranceInfo == null) {
-            Log.trace(
-                AnalyticsConstants.LOG_TAG,
-                LOG_TAG,
-                "extractAssuranceInfo - Failed to extract assurance data (event data was null)."
-            )
-            return
-        }
+    private fun extractAssuranceInfo(assuranceInfo: Map<String, Any?>) {
         val assuranceSessionId = DataReader.optString(
             assuranceInfo,
             AnalyticsConstants.EventDataKeys.Assurance.SESSION_ID,

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
@@ -12,7 +12,6 @@
 package com.adobe.marketing.mobile.analytics.internal
 
 import com.adobe.marketing.mobile.MobilePrivacyStatus
-import com.adobe.marketing.mobile.internal.util.VisitorIDSerializer
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.util.DataReader
 import com.adobe.marketing.mobile.util.DataReaderException
@@ -198,12 +197,11 @@ internal class AnalyticsState {
         )
         if (identityInfo.containsKey(AnalyticsConstants.EventDataKeys.Identity.VISITOR_IDS_LIST)) {
             try {
-                val list = DataReader.getTypedList(
-                    Map::class.java,
+                val visitorIdsList = DataReader.getTypedListOfMap(
+                    Object::class.java,
                     identityInfo,
                     AnalyticsConstants.EventDataKeys.Identity.VISITOR_IDS_LIST
                 )
-                val visitorIdsList = VisitorIDSerializer.convertToVisitorIds(list)
                 serializedVisitorIDsList =
                     AnalyticsRequestSerializer.generateAnalyticsCustomerIdString(visitorIdsList)
             } catch (ex: DataReaderException) {

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsFunctionalTestBase.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsFunctionalTestBase.kt
@@ -15,6 +15,7 @@ import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.ExtensionApi
+import com.adobe.marketing.mobile.MobilePrivacyStatus
 import com.adobe.marketing.mobile.SharedStateResult
 import com.adobe.marketing.mobile.SharedStateStatus
 import com.adobe.marketing.mobile.analytics.internal.AnalyticsExtension
@@ -151,6 +152,27 @@ internal open class AnalyticsFunctionalTestBase {
         }
         return AnalyticsExtension(
             mockedExtensionApi
+        )
+    }
+
+    protected fun config(privacyStatus: MobilePrivacyStatus): Map<String, Any> {
+        return mapOf(
+            "analytics.server" to "test.com",
+            "analytics.rsids" to "rsid",
+            "global.privacy" to privacyStatus.value,
+            "experienceCloud.org" to "orgid",
+            "analytics.batchLimit" to 0,
+            "analytics.offlineEnabled" to true,
+            "analytics.backdatePreviousSessionInfo" to true,
+            "analytics.launchHitDelay" to 1
+        )
+    }
+
+    protected fun defaultIdentity(): Map<String, Any> {
+        return mapOf(
+            "mid" to "mid",
+            "blob" to "blob",
+            "locationhint" to "lochint"
         )
     }
 }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsFunctionalTestBase.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsFunctionalTestBase.kt
@@ -22,6 +22,8 @@ import com.adobe.marketing.mobile.analytics.internal.AnalyticsExtension
 import com.adobe.marketing.mobile.analytics.internal.MemoryDataQueue
 import com.adobe.marketing.mobile.analytics.internal.MockedHttpConnecting
 import com.adobe.marketing.mobile.analytics.internal.NetworkMonitor
+import com.adobe.marketing.mobile.services.AppContextService
+import com.adobe.marketing.mobile.services.AppState
 import com.adobe.marketing.mobile.services.DataQueue
 import com.adobe.marketing.mobile.services.DataQueuing
 import com.adobe.marketing.mobile.services.DataStoring
@@ -35,6 +37,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.anyOrNull
 
@@ -63,6 +66,9 @@ internal open class AnalyticsFunctionalTestBase {
 
     @Mock
     protected lateinit var mockedNameCollection: NamedCollection
+
+    @Mock
+    protected lateinit var mockedAppContextService: AppContextService
 
     private val mockedSharedState: MutableMap<String, Map<String, Any>> = mutableMapOf()
 
@@ -108,6 +114,15 @@ internal open class AnalyticsFunctionalTestBase {
                 }
             }
         )
+
+        `when`(mockedAppContextService.appState).thenReturn(AppState.FOREGROUND)
+        val appContextField =
+            ServiceProvider.getInstance().javaClass.getDeclaredField("overrideAppContextService")
+        appContextField.isAccessible = true
+        appContextField.set(
+            serviceProvider,
+            mockedAppContextService
+        )
     }
 
     fun monitorNetwork(networkMonitor: NetworkMonitor) {
@@ -138,7 +153,7 @@ internal open class AnalyticsFunctionalTestBase {
     ): AnalyticsExtension {
         configuration?.let { mockedSharedState["com.adobe.module.configuration"] = it }
         identity?.let { mockedSharedState["com.adobe.module.identity"] = it }
-        Mockito.`when`(
+        `when`(
             mockedExtensionApi.getSharedState(
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any(),

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsIDTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsIDTests.kt
@@ -626,25 +626,4 @@ internal class AnalyticsIDTests : AnalyticsFunctionalTestBase() {
         countDownLatch.await()
         assertTrue(analyticsSharedState1.isEmpty())
     }
-
-    private fun config(privacyStatus: MobilePrivacyStatus): Map<String, Any> {
-        return mapOf(
-            "analytics.server" to "test.com",
-            "analytics.rsids" to "rsid",
-            "global.privacy" to privacyStatus.value,
-            "experienceCloud.org" to "orgid",
-            "analytics.batchLimit" to 0,
-            "analytics.offlineEnabled" to true,
-            "analytics.backdatePreviousSessionInfo" to true,
-            "analytics.launchHitDelay" to 1
-        )
-    }
-
-    private fun defaultIdentity(): Map<String, Any> {
-        return mapOf(
-            "mid" to "mid",
-            "blob" to "blob",
-            "locationhint" to "lochint"
-        )
-    }
 }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsQueueTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsQueueTests.kt
@@ -53,11 +53,7 @@ internal class AnalyticsQueueTests : AnalyticsFunctionalTestBase() {
                 "analytics.launchHitDelay" to 5,
                 "analytics.batchLimit" to 5
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val event1 = Event.Builder(
@@ -133,11 +129,7 @@ internal class AnalyticsQueueTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 5
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val event1 = Event.Builder(
@@ -190,11 +182,7 @@ internal class AnalyticsQueueTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 5
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val event1 = Event.Builder(
@@ -262,11 +250,7 @@ internal class AnalyticsQueueTests : AnalyticsFunctionalTestBase() {
                 "analytics.launchHitDelay" to 5,
                 "analytics.batchLimit" to 2
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val event1 = Event.Builder(
@@ -326,11 +310,7 @@ internal class AnalyticsQueueTests : AnalyticsFunctionalTestBase() {
                 "analytics.launchHitDelay" to 1,
                 "analytics.batchLimit" to 5
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val event1 = Event.Builder(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackAssuranceTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackAssuranceTests.kt
@@ -43,11 +43,7 @@ internal class AnalyticsTrackAssuranceTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         updateMockedSharedState("com.adobe.assurance", mapOf("sessionid" to "session_id"))
@@ -91,11 +87,7 @@ internal class AnalyticsTrackAssuranceTests : AnalyticsFunctionalTestBase() {
                 "analytics.launchHitDelay" to 1,
                 "analytics.batchLimit" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent1 = Event.Builder(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackConfigurationTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackConfigurationTests.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.analytics.function.test
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.MobilePrivacyStatus
 import com.adobe.marketing.mobile.analytics.internal.TimeZoneHelper
 import com.adobe.marketing.mobile.analytics.internal.extractContextDataFrom
 import com.adobe.marketing.mobile.analytics.internal.extractQueryParamsFrom
@@ -116,16 +117,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
 
         updateMockedSharedState(
             "com.adobe.module.configuration",
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedout",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            )
+            config(MobilePrivacyStatus.OPT_OUT)
         )
         analyticsExtension.handleIncomingEvent(
             Event.Builder(
@@ -194,16 +186,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
 
         updateMockedSharedState(
             "com.adobe.module.configuration",
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            )
+            config(MobilePrivacyStatus.OPT_IN)
         )
         analyticsExtension.handleIncomingEvent(
             Event.Builder(
@@ -282,16 +265,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
 
         updateMockedSharedState(
             "com.adobe.module.configuration",
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            )
+            config(MobilePrivacyStatus.OPT_IN)
         )
         analyticsExtension.handleIncomingEvent(
             Event.Builder(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackConfigurationTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackConfigurationTests.kt
@@ -77,11 +77,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent1 = Event.Builder(
@@ -177,11 +173,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -269,11 +261,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent1 = Event.Builder(
@@ -374,11 +362,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -438,11 +422,7 @@ internal class AnalyticsTrackConfigurationTests : AnalyticsFunctionalTestBase() 
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackLifecycleTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackLifecycleTests.kt
@@ -445,11 +445,7 @@ internal class AnalyticsTrackLifecycleTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         updateMockedSharedState(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackPlacesTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackPlacesTests.kt
@@ -48,11 +48,7 @@ internal class AnalyticsTrackPlacesTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         updateMockedSharedState(
@@ -131,11 +127,7 @@ internal class AnalyticsTrackPlacesTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         updateMockedSharedState(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackTargetTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackTargetTests.kt
@@ -48,11 +48,7 @@ internal class AnalyticsTrackTargetTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackTests.kt
@@ -14,11 +14,13 @@ package com.adobe.marketing.mobile.analytics.function.test
 import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.MobilePrivacyStatus
 import com.adobe.marketing.mobile.analytics.internal.TimeZoneHelper
 import com.adobe.marketing.mobile.analytics.internal.extractContextDataFrom
 import com.adobe.marketing.mobile.analytics.internal.extractContextDataKVPairFrom
 import com.adobe.marketing.mobile.analytics.internal.extractQueryParamsFrom
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Ignore
 import org.junit.Test
 import java.net.URLDecoder
@@ -40,24 +42,11 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "state" to "testState",
                 "contextdata" to mapOf(
@@ -65,7 +54,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "k2" to "v2"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -105,24 +94,11 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "action" to "testAction",
                 "contextdata" to mapOf(
@@ -130,7 +106,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "k2" to "v2"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -172,24 +148,11 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "action" to "testAction",
                 "trackinternal" to true,
@@ -198,7 +161,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "k2" to "v2"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -240,31 +203,18 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "contextdata" to mapOf(
                     "k1" to "v1",
                     "k2" to "v2"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -303,16 +253,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
         updateMockedSharedState(
@@ -325,11 +266,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 )
             )
         )
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "contextdata" to mapOf(
                     "k1" to "v1",
@@ -339,7 +276,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "a.OSVersion" to "overwrittenOS"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -383,24 +320,11 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "state" to "testState",
                 "action" to "testAction",
@@ -409,7 +333,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "k2" to "v2"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -452,24 +376,11 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "state" to "~!@#\$%^&*()_.-+",
                 "action" to "网页",
@@ -479,7 +390,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "k1" to "网页"
                 )
             )
-        ).build()
+        )
 
         analyticsExtension.handleIncomingEvent(trackEvent)
 
@@ -518,24 +429,11 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         }
 
         val analyticsExtension = initializeAnalyticsExtensionWithPreset(
-            mapOf(
-                "analytics.server" to "test.com",
-                "analytics.rsids" to "rsid",
-                "global.privacy" to "optedin",
-                "experienceCloud.org" to "orgid",
-                "analytics.batchLimit" to 0,
-                "analytics.offlineEnabled" to true,
-                "analytics.backdatePreviousSessionInfo" to true,
-                "analytics.launchHitDelay" to 1
-            ),
+            config(MobilePrivacyStatus.OPT_IN),
             defaultIdentity()
         )
 
-        val trackEvent = Event.Builder(
-            "Generic track event",
-            EventType.GENERIC_TRACK,
-            EventSource.REQUEST_CONTENT
-        ).setEventData(
+        val trackEvent = trackEventWithData(
             mapOf(
                 "contextdata" to mapOf(
                     "StringValue" to "v1",
@@ -550,7 +448,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                     "DictValue" to emptyMap<Any, Any>()
                 )
             )
-        ).build()
+        )
         // TODO: the event data was set to null because of the above unsupported value types, like emptyArray.
 
         analyticsExtension.handleIncomingEvent(trackEvent)
@@ -573,5 +471,71 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
         Assert.assertTrue(expectedContextData == contextDataMap)
         Assert.assertEquals(expectedVars.size, varMap.size)
         Assert.assertEquals(expectedVars, varMap)
+    }
+
+    @Test
+    fun `track request should be ignored when privacy opted out`() {
+        val analyticsExtension = initializeAnalyticsExtensionWithPreset(
+            config(MobilePrivacyStatus.OPT_OUT),
+            defaultIdentity()
+        )
+
+        val trackEvent = trackEventWithData(
+            mapOf(
+                "state" to "testState",
+                "contextdata" to mapOf(
+                    "k1" to "v1",
+                    "k2" to "v2"
+                )
+            )
+        )
+
+        analyticsExtension.handleIncomingEvent(trackEvent)
+
+        assertEquals(0, mockedMainDataQueue.count())
+    }
+
+    @Test
+    fun `track request should be queued when privacy unknown`() {
+        val analyticsExtension = initializeAnalyticsExtensionWithPreset(
+            config(MobilePrivacyStatus.UNKNOWN),
+            defaultIdentity()
+        )
+
+        val trackEvent = trackEventWithData(
+            mapOf(
+                "state" to "testState",
+                "contextdata" to mapOf(
+                    "k1" to "v1",
+                    "k2" to "v2"
+                )
+            )
+        )
+
+        analyticsExtension.handleIncomingEvent(trackEvent)
+
+        assertEquals(1, mockedMainDataQueue.count())
+    }
+
+    @Test
+    fun `track request should be ignored when no data`() {
+        val analyticsExtension = initializeAnalyticsExtensionWithPreset(
+            config(MobilePrivacyStatus.OPT_IN),
+            defaultIdentity()
+        )
+
+        val trackEvent = trackEventWithData(emptyMap())
+
+        analyticsExtension.handleIncomingEvent(trackEvent)
+
+        assertEquals(0, mockedMainDataQueue.count())
+    }
+
+    private fun trackEventWithData(data: Map<String, Any?>): Event {
+        return Event.Builder(
+            "Generic track event",
+            EventType.GENERIC_TRACK,
+            EventSource.REQUEST_CONTENT
+        ).setEventData(data).build()
     }
 }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackTests.kt
@@ -50,11 +50,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -119,11 +115,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -190,11 +182,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -262,11 +250,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -329,11 +313,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
         updateMockedSharedState(
             "com.adobe.module.lifecycle",
@@ -413,11 +393,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -486,11 +462,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(
@@ -556,11 +528,7 @@ internal class AnalyticsTrackTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val trackEvent = Event.Builder(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/ConsequenceRuleTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/ConsequenceRuleTests.kt
@@ -38,11 +38,7 @@ internal class ConsequenceRuleTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 0
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
 
         val eventData: Map<String, Any> = mapOf(

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/HitReorderTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/HitReorderTests.kt
@@ -49,11 +49,7 @@ internal class HitReorderTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
         val lifecycleStartEvent = Event.Builder(
             "lifecycle start",
@@ -310,11 +306,7 @@ internal class HitReorderTests : AnalyticsFunctionalTestBase() {
                 "analytics.backdatePreviousSessionInfo" to true,
                 "analytics.launchHitDelay" to 1
             ),
-            mapOf(
-                "mid" to "mid",
-                "blob" to "blob",
-                "locationhint" to "lochint"
-            )
+            defaultIdentity()
         )
         val trackEvent = Event.Builder(
             "track event",

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsRequestSerializerTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsRequestSerializerTests.kt
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.analytics.internal
 
-import com.adobe.marketing.mobile.VisitorID
 import org.junit.Assert
 import org.junit.Test
 import java.util.*
@@ -23,37 +22,37 @@ class AnalyticsRequestSerializerTests {
 
     @Test
     fun testGenerateAnalyticsCustomerIdString_happyFlow() {
-        val visitorIDList: MutableList<VisitorID> = ArrayList()
+        val visitorIDList: MutableList<MutableMap<String, Any?>> = ArrayList()
         visitorIDList.add(
-            VisitorID(
-                "d_cid_ic",
-                "loginidhash",
-                "97717",
-                VisitorID.AuthenticationState.UNKNOWN
+            mutableMapOf(
+                "ID_ORIGIN" to "d_cid_ic",
+                "ID_TYPE" to "loginidhash",
+                "ID" to "97717",
+                "STATE" to 0 // unknown
             )
         )
         visitorIDList.add(
-            VisitorID(
-                "d_cid_ic",
-                "xboxlivehash",
-                "1629158955",
-                VisitorID.AuthenticationState.AUTHENTICATED
+            mutableMapOf(
+                "ID_ORIGIN" to "d_cid_ic",
+                "ID_TYPE" to "xboxlivehash",
+                "ID" to "1629158955",
+                "STATE" to 1 // authenticated
             )
         )
         visitorIDList.add(
-            VisitorID(
-                "d_cid_ic",
-                "psnidhash",
-                "1144032295",
-                VisitorID.AuthenticationState.LOGGED_OUT
+            mutableMapOf(
+                "ID_ORIGIN" to "d_cid_ic",
+                "ID_TYPE" to "psnidhash",
+                "ID" to "1144032295",
+                "STATE" to 2 // logged out
             )
         )
         visitorIDList.add(
-            VisitorID(
-                "d_cid",
-                "pushid",
-                "testPushId",
-                VisitorID.AuthenticationState.AUTHENTICATED
+            mutableMapOf(
+                "ID_ORIGIN" to "d_cid",
+                "ID_TYPE" to "pushid",
+                "ID" to "testPushId",
+                "STATE" to 1 // authenticated
             )
         )
         val expectedString =

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
@@ -121,6 +121,20 @@ class AnalyticsStateTests {
     }
 
     @Test
+    fun testExtractLifecycleInfo_returnsDefaultValues_when_empty() {
+        val state = AnalyticsState()
+        state.update(
+            mapOf(
+                LIFECYCLE_SHARED_STATE to emptyMap()
+            )
+        )
+        assertTrue(state.defaultData.isEmpty())
+        assertNull(state.applicationID)
+        assertEquals(0, state.lifecycleSessionStartTimestamp)
+        assertEquals(0, state.lifecycleMaxSessionLength)
+    }
+
+    @Test
     fun testExtractPlacesInfo_happyFlow() {
         val state = AnalyticsState()
         state.update(
@@ -186,6 +200,38 @@ class AnalyticsStateTests {
         assertNull(state.blob)
         assertNull(state.locationHint)
         assertNull(state.serializedVisitorIDsList)
+    }
+
+    @Test
+    fun testExtractIdentityInfo_extractsCustomVisitorIds() {
+        val state = AnalyticsState()
+        val customIds = arrayListOf<Map<String, Any?>>()
+        customIds.add(
+            mapOf(
+                "ID" to "id1",
+                "ID_ORIGIN" to "d_cid_ic",
+                "ID_TYPE" to "id_type1",
+                "STATE" to 1
+            ) // authenticated
+        )
+        customIds.add(
+            mapOf(
+                "ID" to "id2",
+                "ID_ORIGIN" to "d_cid_ic",
+                "ID_TYPE" to "id_type2",
+                "STATE" to 2
+            ) // logged out
+        )
+        state.update(
+            mapOf(
+                IDENTITY_SHARED_STATE to mapOf(
+                    "mid" to "testMID",
+                    "visitoridslist" to customIds
+                )
+            )
+        )
+        assertEquals("testMID", state.marketingCloudId)
+        assertEquals("&cid.&id_type1.&as=1&id=id1&.id_type1&id_type2.&as=2&id=id2&.id_type2&.cid", state.serializedVisitorIDsList)
     }
 
     @Test

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
@@ -146,7 +146,6 @@ class AnalyticsStateTests {
                         "regionid" to "sampleRegionId",
                         "regionname" to "sampleRegionName"
                     )
-
                 )
             )
         )
@@ -165,6 +164,50 @@ class AnalyticsStateTests {
         state.update(
             mapOf(
                 PLACES_SHARED_STATE to null
+            )
+        )
+        assertTrue(state.defaultData.isEmpty())
+    }
+
+    @Test
+    fun testExtractPlacesInfo_returnsDefaultValuesAndDoesNotCrash_when_invalidType() {
+        state.update(
+            mapOf(
+                PLACES_SHARED_STATE to mapOf(
+                    "someotherpoihere" to mapOf(
+                        "unexpectedformat" to true
+                    )
+                )
+            )
+        )
+        assertTrue(state.defaultData.isEmpty())
+    }
+
+    @Test
+    fun testExtractPlacesInfo_shouldNotIncludeNullValues() {
+        state.update(
+            mapOf(
+                PLACES_SHARED_STATE to mapOf(
+                    "currentpoi" to mapOf(
+                        "regionid" to null,
+                        "regionname" to null
+                    )
+                )
+            )
+        )
+        assertTrue(state.defaultData.isEmpty())
+    }
+
+    @Test
+    fun testExtractPlacesInfo_shouldNotIncludeEmptyValues() {
+        state.update(
+            mapOf(
+                PLACES_SHARED_STATE to mapOf(
+                    "currentpoi" to mapOf(
+                        "regionid" to "",
+                        "regionname" to ""
+                    )
+                )
             )
         )
         assertTrue(state.defaultData.isEmpty())
@@ -380,6 +423,34 @@ class AnalyticsStateTests {
             )
         )
         assertEquals(emptyMap<String, Any>(), state.analyticsIdVisitorParameters)
+    }
+
+    @Test
+    fun testGetAnalyticsIdVisitorParameters_shouldNotIncludeNullValues_butMid() {
+        state.update(
+            mapOf(
+                IDENTITY_SHARED_STATE to mapOf(
+                    "mid" to "mid",
+                    "blob" to null,
+                    "locationhint" to null
+                )
+            )
+        )
+        assertEquals(mapOf("mid" to "mid"), state.analyticsIdVisitorParameters)
+    }
+
+    @Test
+    fun testGetAnalyticsIdVisitorParameters_shouldNotIncludeEmptyValues_butMid() {
+        state.update(
+            mapOf(
+                IDENTITY_SHARED_STATE to mapOf(
+                    "mid" to "mid",
+                    "blob" to "",
+                    "locationhint" to ""
+                )
+            )
+        )
+        assertEquals(mapOf("mid" to "mid"), state.analyticsIdVisitorParameters)
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Adds new tests to increase code coverage to 90%
- Added few helper functions for test body size reduction
- Removes internal usages of VisitorID objects and VisitorIDSerializer, uses DataReader and base types, and adds more tests on serializing custom visitor ids

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
