### PR TITLE
Fix initialization for lastResetIdentitiesTs (resolves #58)

### DIFF
--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
@@ -183,7 +183,8 @@ internal class AnalyticsHitProcessor(
                         Log.debug(
                             AnalyticsConstants.LOG_TAG,
                             CLASS_NAME,
-                            "processHit - Dispatching Analytics hit response."
+                            "processHit - Dispatching Analytics hit response for request event id %s.",
+                            eventIdentifier
                         )
                         extensionApi.dispatch(
                             Event.Builder(
@@ -191,6 +192,13 @@ internal class AnalyticsHitProcessor(
                                 EventType.ANALYTICS,
                                 EventSource.RESPONSE_CONTENT
                             ).setEventData(eventData).build()
+                        )
+                    } else {
+                        Log.debug(
+                            AnalyticsConstants.LOG_TAG,
+                            CLASS_NAME,
+                            "processHit - Ignoring response for request event id %s as it was received while processing a resetIdentities event.",
+                            eventIdentifier
                         )
                     }
                     lastHitTimestamp = timestamp

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
@@ -16,7 +16,6 @@ import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.util.DataReader
 import com.adobe.marketing.mobile.util.DataReaderException
 import com.adobe.marketing.mobile.util.StringUtils
-import com.adobe.marketing.mobile.util.TimeUtils
 import java.util.HashMap
 
 /**
@@ -27,7 +26,8 @@ class AnalyticsState {
     internal var host: String? = null
         private set
 
-    internal var lastResetIdentitiesTimestampSec: Long = TimeUtils.getUnixTimeInSeconds()
+    // Store the timestamp for most recent resetIdentities API call
+    internal var lastResetIdentitiesTimestampSec: Long = 0L
 
     // ----------- Configuration properties -----------
     internal var isAnalyticsForwardingEnabled: Boolean =

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessorTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessorTests.kt
@@ -84,8 +84,8 @@ class AnalyticsHitProcessorTests {
         networkMonitor = { request ->
             networkRequest = request
         }
-        analyticsHitProcessor.processHit(badDataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(badDataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -106,8 +106,8 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
             countDownLatch.countDown()
         }
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertFalse(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertFalse(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -127,8 +127,8 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
             countDownLatch.countDown()
         }
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -159,8 +159,8 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -219,8 +219,8 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(timestamp + 10, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -263,8 +263,8 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
         }
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -288,8 +288,8 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
         }
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertFalse(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertFalse(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -325,8 +325,8 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertFalse(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertFalse(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -357,8 +357,8 @@ class AnalyticsHitProcessorTests {
             countDownLatch.countDown()
         }
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -412,8 +412,8 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()
@@ -446,8 +446,8 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(dataEntity) {
-            assertTrue(it)
+        analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
+            assertTrue(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessorTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessorTests.kt
@@ -97,7 +97,7 @@ class AnalyticsHitProcessorTests {
     fun `network failure - recoverable error`() {
         val countDownLatch = CountDownLatch(2)
         val analyticsHitProcessor = initAnalyticsHitProcessor()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit("payload1", TimeUtils.getUnixTimeInSeconds(), "id1").toDataEntity()
         var networkRequest: NetworkRequest? = null
         // 408, 504, 503, -1
@@ -106,7 +106,7 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
             countDownLatch.countDown()
         }
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertFalse(it)
             countDownLatch.countDown()
         }
@@ -118,7 +118,7 @@ class AnalyticsHitProcessorTests {
     fun `network failure - 404 error`() {
         val countDownLatch = CountDownLatch(2)
         val analyticsHitProcessor = initAnalyticsHitProcessor()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit("payload1", TimeUtils.getUnixTimeInSeconds(), "id1").toDataEntity()
         var networkRequest: NetworkRequest? = null
         // 408, 504, 503, -1
@@ -127,7 +127,7 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
             countDownLatch.countDown()
         }
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertTrue(it)
             countDownLatch.countDown()
         }
@@ -142,7 +142,7 @@ class AnalyticsHitProcessorTests {
         val payload =
             "ndh=1&ce=UTF-8&c.&a.&action=testAction&.a&k1=v1&k2=v2&.c&t=00%2F00%2F0000%2000%3A00%3A00%200%20420&pe=lnk_o&pev2=AMACTION%3AtestAction&aamb=blob&mid=mid&aamlh=lochint&cp=foreground&ts=1669845066"
         val timestamp = TimeUtils.getUnixTimeInSeconds()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit(payload, timestamp, "id1").toDataEntity()
         mockedHttpConnecting.responseCode = 200
         mockedHttpConnecting.responseProperties = mapOf(
@@ -159,7 +159,7 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertTrue(it)
             countDownLatch.countDown()
         }
@@ -202,7 +202,7 @@ class AnalyticsHitProcessorTests {
         analyticsHitProcessor.setLastHitTimestamp(
             timestamp + 10
         )
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit(payload, timestamp, "id1").toDataEntity()
         mockedHttpConnecting.responseCode = 200
         mockedHttpConnecting.responseProperties = mapOf(
@@ -219,7 +219,7 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(timestamp + 10, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertTrue(it)
             countDownLatch.countDown()
         }
@@ -256,14 +256,14 @@ class AnalyticsHitProcessorTests {
         val countDownLatch = CountDownLatch(1)
         val analyticsHitProcessor = initAnalyticsHitProcessor()
         val currentTimestamp = TimeUtils.getUnixTimeInSeconds()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit("payload", currentTimestamp - 65, "id1").toDataEntity()
         var networkRequest: NetworkRequest? = null
         networkMonitor = { request ->
             networkRequest = request
         }
 
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertTrue(it)
             countDownLatch.countDown()
         }
@@ -281,14 +281,14 @@ class AnalyticsHitProcessorTests {
         val countDownLatch = CountDownLatch(1)
         val analyticsHitProcessor = initAnalyticsHitProcessor()
         val currentTimestamp = TimeUtils.getUnixTimeInSeconds()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit("payload", currentTimestamp - 65, "id1").toDataEntity()
         var networkRequest: NetworkRequest? = null
         networkMonitor = { request ->
             networkRequest = request
         }
 
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertFalse(it)
             countDownLatch.countDown()
         }
@@ -395,7 +395,7 @@ class AnalyticsHitProcessorTests {
         val payload =
             "ndh=1&ce=UTF-8&c.&a.&action=testAction&.a&k1=v1&k2=v2&.c&t=00%2F00%2F0000%2000%3A00%3A00%200%20420&pe=lnk_o&pev2=AMACTION%3AtestAction&aamb=blob&mid=mid&aamlh=lochint&cp=foreground&ts=1669845066"
         val timestamp = TimeUtils.getUnixTimeInSeconds()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit(payload, timestamp, "id1").toDataEntity()
         mockedHttpConnecting.responseCode = 200
         mockedHttpConnecting.responseProperties = mapOf(
@@ -412,7 +412,7 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertTrue(it)
             countDownLatch.countDown()
         }
@@ -429,7 +429,7 @@ class AnalyticsHitProcessorTests {
         val payload =
             "ndh=1&ce=UTF-8&c.&a.&action=testAction&.a&k1=v1&k2=v2&.c&t=00%2F00%2F0000%2000%3A00%3A00%200%20420&pe=lnk_o&pev2=AMACTION%3AtestAction&aamb=blob&mid=mid&aamlh=lochint&cp=foreground&ts=1669845066"
         val timestamp = TimeUtils.getUnixTimeInSeconds()
-        val badDataEntity =
+        val dataEntity =
             AnalyticsHit(payload, timestamp, "id1").toDataEntity()
         mockedHttpConnecting.responseCode = 200
         mockedHttpConnecting.responseProperties = mapOf(
@@ -446,7 +446,7 @@ class AnalyticsHitProcessorTests {
 
         assertEquals(0, analyticsHitProcessor.getLastHitTimestamp())
 
-        analyticsHitProcessor.processHit(badDataEntity) {
+        analyticsHitProcessor.processHit(dataEntity) {
             assertTrue(it)
             countDownLatch.countDown()
         }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
@@ -457,4 +457,9 @@ class AnalyticsStateTests {
     fun testGetAnalyticsIdVisitorParametersWhenVisitorDataIsAbsent() {
         assertTrue(state.analyticsIdVisitorParameters.isEmpty())
     }
+
+    @Test
+    fun testLastResetIdentitiesTimestampSec_shouldBeZeroByDefault() {
+        assertEquals(0L, state.lastResetIdentitiesTimestampSec)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
lastResetIdentitiesTimestampSec should be initialized with 0 by default, and updated when resetIdentities events are processed. 
Previously it was set to current timestamp, preventing the analytics response event to be dispatched for track events sent on bootup.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
Manual tests with test app and Assurance connection

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
