### PR TITLE
Network retry changes 

### DIFF
--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
@@ -252,7 +252,7 @@ internal class AnalyticsHitProcessor(
             Log.debug(
                 AnalyticsConstants.LOG_TAG,
                 CLASS_NAME,
-                "getAnalyticsBaseUrl - The Analytics configuration for RSID or host is not ready, as they appear to be empty or null."
+                "getAnalyticsBaseUrl - The Analytics configuration for RSID or host is not found. RSID and host must not be null or empty."
             )
             return null
         }

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
@@ -114,23 +114,13 @@ internal class AnalyticsHitProcessor(
             timestamp = newTimestamp
         }
 
-        if (!analyticsState.isAnalyticsConfigured) {
-            Log.debug(
-                AnalyticsConstants.LOG_TAG,
-                CLASS_NAME,
-                "processHit - The Analytics configuration for RSID or host is incomplete or incorrectly set up, as they appear to be empty or null, retrying Analytics hit."
-            )
-            processingResult.complete(false)
-            return
-        }
-
         val url = getAnalyticsBaseUrl(analyticsState) ?: run {
             Log.debug(
                 AnalyticsConstants.LOG_TAG,
                 CLASS_NAME,
-                "processHit - Error generating base url due to the url not valid, dropping the hit."
+                "processHit - Retrying Analytics hit, error generating base url."
             )
-            processingResult.complete(true)
+            processingResult.complete(false)
             return@processHit
         }
 
@@ -258,6 +248,14 @@ internal class AnalyticsHitProcessor(
      * @return a URL for use in Analytics hits or null if the URL could not be built
      */
     private fun getAnalyticsBaseUrl(state: AnalyticsState): String? {
+        if (!state.isAnalyticsConfigured) {
+            Log.debug(
+                AnalyticsConstants.LOG_TAG,
+                CLASS_NAME,
+                "getAnalyticsBaseUrl - The Analytics configuration for RSID or host is not ready, as they appear to be empty or null."
+            )
+            return null
+        }
         val baseUrl =
             "https://${state.host}/b/ss/${state.rsids ?: ""}/${getAnalyticsResponseType(state)}/$version/s${(0..100000000).random()}"
         if (!UrlUtils.isValidUrl(baseUrl)) {

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
@@ -118,7 +118,7 @@ internal class AnalyticsHitProcessor(
             Log.debug(
                 AnalyticsConstants.LOG_TAG,
                 CLASS_NAME,
-                "processHit - Analytics has not been configured properly for RSID or host, retrying Analytics hit."
+                "processHit - The Analytics configuration for RSID or host is incomplete or incorrectly set up, as they appear to be empty or null, retrying Analytics hit."
             )
             processingResult.complete(false)
             return

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessor.kt
@@ -141,7 +141,7 @@ internal class AnalyticsHitProcessor(
 
         networkService.connectAsync(networkRequest) { connection ->
             if (connection == null) {
-                Log.warning(
+                Log.debug(
                     AnalyticsConstants.LOG_TAG,
                     CLASS_NAME,
                     "processHit - Retrying Analytics hit, there is currently no network connectivity"
@@ -206,7 +206,7 @@ internal class AnalyticsHitProcessor(
                     doneProcessingResult = true
                 }
                 in arrayOf(408, 504, 503, -1) -> {
-                    Log.warning(
+                    Log.debug(
                         AnalyticsConstants.LOG_TAG,
                         CLASS_NAME,
                         "processHit - Retrying Analytics hit, request with url $url failed with recoverable status code ${connection.responseCode}"

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessorTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsHitProcessorTests.kt
@@ -335,7 +335,7 @@ class AnalyticsHitProcessorTests {
     }
 
     @Test
-    fun `hit should be dropped with no retry when URL is malformed`() {
+    fun `hit should be retried when URL is malformed`() {
         // malformed URL
         Mockito.`when`(mockedAnalyticsState.host).thenReturn("adobe.com:_80")
 
@@ -351,7 +351,7 @@ class AnalyticsHitProcessorTests {
             networkRequest = request
         }
         analyticsHitProcessor.processHit(dataEntity) { processingComplete ->
-            assertTrue(processingComplete)
+            assertFalse(processingComplete)
             countDownLatch.countDown()
         }
         countDownLatch.await()


### PR DESCRIPTION
Tested Analytics connection for the  latest NetworkService changes ((https://github.com/adobe/aepsdk-core-android/pull/612)

Analytics network connection == null is in place, it already retries when the connection returns null.
The invalid Analytics Configuration and  base url will be retried as previous implementation.

Added malformed url unit test in this PR.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
