### PR TITLE
Fix bug in Places parsing where only String types are assumed

### DIFF
--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsState.kt
@@ -222,17 +222,17 @@ class AnalyticsState {
      */
     private fun extractPlacesInfo(placesInfo: Map<String, Any?>) {
         val placesContextData = DataReader.optTypedMap(
-            String::class.java,
+            Object::class.java,
             placesInfo,
             AnalyticsConstants.EventDataKeys.Places.CURRENT_POI,
             null
         ) ?: return
-        val regionId = placesContextData[AnalyticsConstants.EventDataKeys.Places.REGION_ID]
+        val regionId = placesContextData[AnalyticsConstants.EventDataKeys.Places.REGION_ID] as? String
         if (!StringUtils.isNullOrEmpty(regionId)) {
             defaultData[AnalyticsConstants.ContextDataKeys.REGION_ID] =
                 regionId ?: ""
         }
-        val regionName = placesContextData[AnalyticsConstants.EventDataKeys.Places.REGION_NAME]
+        val regionName = placesContextData[AnalyticsConstants.EventDataKeys.Places.REGION_NAME] as? String
         if (!StringUtils.isNullOrEmpty(regionName)) {
             defaultData[AnalyticsConstants.ContextDataKeys.REGION_NAME] =
                 regionName ?: ""

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackPlacesTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackPlacesTests.kt
@@ -97,7 +97,100 @@ internal class AnalyticsTrackPlacesTests : AnalyticsFunctionalTestBase() {
             "a.loc.poi.id" to "myRegionId",
             "a.loc.poi" to "myRegionName"
         )
-        Assert.assertTrue(expectedContextData == contextDataMap)
+        Assert.assertEquals(expectedContextData, contextDataMap)
+        Assert.assertEquals(expectedVars.size, varMap.size)
+        Assert.assertEquals(expectedVars, varMap)
+    }
+
+    @Test(timeout = 10000)
+    fun `analytics hit contains current poi places data`() {
+        val countDownLatch = CountDownLatch(1)
+        var varMap: Map<String, Any> = emptyMap()
+        var contextDataMap: Map<String, Any> = emptyMap()
+        monitorNetwork { request ->
+            if (request.url.startsWith("https://test.com/b/ss/rsid/0/")) {
+                val body = URLDecoder.decode(String(request.body), "UTF-8")
+                varMap = extractQueryParamsFrom(body)
+                contextDataMap = extractContextDataFrom(body)
+                countDownLatch.countDown()
+            }
+        }
+
+        val analyticsExtension = initializeAnalyticsExtensionWithPreset(
+            mapOf(
+                "analytics.server" to "test.com",
+                "analytics.rsids" to "rsid",
+                "global.privacy" to "optedin",
+                "experienceCloud.org" to "orgid",
+                "analytics.batchLimit" to 0,
+                "analytics.offlineEnabled" to true,
+                "analytics.backdatePreviousSessionInfo" to true,
+                "analytics.launchHitDelay" to 1
+            ),
+            defaultIdentity()
+        )
+
+        // Test with full shared state to validate parsing/casting of types
+        updateMockedSharedState(
+            "com.adobe.module.places",
+            mapOf(
+                "currentpoi" to mapOf(
+                    "regionid" to "99306680-a0e5-49f1-b0eb-c52c6e05ce01",
+                    "useriswithin" to true,
+                    "latitude" to 37.3309257,
+                    "libraryid" to "311cbfb0-ac5e-436a-b22d-4a917426880d",
+                    "regionname" to  "Adobe 100",
+                    "weight" to 1,
+                    "regionmetadata" to mapOf(
+                        "country" to "Adobe 100",
+                        "city" to "Adobe 100",
+                        "street" to "Adobe 100",
+                        "state" to "Adobe 100",
+                        "category" to "Adobe 100"
+                    ),
+                    "radius" to 100,
+                    "longitude" to -121.8939791
+                )
+            )
+        )
+
+        val trackEvent = Event.Builder(
+            "track event",
+            EventType.GENERIC_TRACK,
+            EventSource.REQUEST_CONTENT
+        ).setEventData(
+            mapOf(
+                "action" to "testActionName",
+                "contextdata" to mapOf(
+                    "k1" to "v1",
+                    "k2" to "v2"
+                )
+            )
+        ).build()
+
+        analyticsExtension.handleIncomingEvent(trackEvent)
+
+        countDownLatch.await()
+        val expectedVars: Map<String, String> = mapOf(
+            "ndh" to "1",
+            "ce" to "UTF-8",
+            "cp" to "foreground",
+            "pev2" to "AMACTION:testActionName",
+            "pe" to "lnk_o",
+            "mid" to "mid",
+            "aamb" to "blob",
+            "aamlh" to "lochint",
+            "t" to TimeZoneHelper.TIMESTAMP_TIMEZONE_OFFSET,
+            "ts" to trackEvent.timestampInSeconds.toString()
+        )
+        val expectedContextData: Map<String, String> = mapOf(
+            "k1" to "v1",
+            "k2" to "v2",
+            "a.action" to "testActionName",
+            "a.loc.poi.id" to "99306680-a0e5-49f1-b0eb-c52c6e05ce01",
+            "a.loc.poi" to "Adobe 100"
+        )
+        Assert.assertEquals(expectedContextData, contextDataMap)
         Assert.assertEquals(expectedVars.size, varMap.size)
         Assert.assertEquals(expectedVars, varMap)
     }
@@ -184,7 +277,7 @@ internal class AnalyticsTrackPlacesTests : AnalyticsFunctionalTestBase() {
             "a.loc.poi.id" to "myRegionId2",
             "a.loc.poi" to "myRegionName2"
         )
-        Assert.assertTrue(expectedContextData == contextDataMap)
+        Assert.assertEquals(expectedContextData, contextDataMap)
         Assert.assertEquals(expectedVars.size, varMap.size)
         Assert.assertEquals(expectedVars, varMap)
     }

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackPlacesTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/function/test/AnalyticsTrackPlacesTests.kt
@@ -139,7 +139,7 @@ internal class AnalyticsTrackPlacesTests : AnalyticsFunctionalTestBase() {
                     "useriswithin" to true,
                     "latitude" to 37.3309257,
                     "libraryid" to "311cbfb0-ac5e-436a-b22d-4a917426880d",
-                    "regionname" to  "Adobe 100",
+                    "regionname" to "Adobe 100",
                     "weight" to 1,
                     "regionmetadata" to mapOf(
                         "country" to "Adobe 100",

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsStateTests.kt
@@ -160,6 +160,41 @@ class AnalyticsStateTests {
     }
 
     @Test
+    fun testExtractPlacesInfo_returnsRegionNameAndID_whenStateContainsOtherTypes() {
+        state.update(
+            mapOf(
+                PLACES_SHARED_STATE to mapOf(
+                    "currentpoi" to mapOf(
+                        "regionid" to "99306680-a0e5-49f1-b0eb-c52c6e05ce01",
+                        "useriswithin" to true,
+                        "latitude" to 37.3309257,
+                        "libraryid" to "311cbfb0-ac5e-436a-b22d-4a917426880d",
+                        "regionname" to "Adobe 100",
+                        "weight" to 1,
+                        "regionmetadata" to mapOf(
+                            "country" to "Adobe 100",
+                            "city" to "Adobe 100",
+                            "street" to "Adobe 100",
+                            "state" to "Adobe 100",
+                            "category" to "Adobe 100"
+                        ),
+                        "radius" to 100,
+                        "longitude" to -121.8939791
+                    )
+                )
+            )
+        )
+        assertEquals(
+            "99306680-a0e5-49f1-b0eb-c52c6e05ce01",
+            state.defaultData[AnalyticsConstants.ContextDataKeys.REGION_ID]
+        )
+        assertEquals(
+            "Adobe 100",
+            state.defaultData[AnalyticsConstants.ContextDataKeys.REGION_NAME]
+        )
+    }
+
+    @Test
     fun testExtractPlacesInfo_returnsDefaultValues_when_empty() {
         state.update(
             mapOf(
@@ -181,6 +216,48 @@ class AnalyticsStateTests {
             )
         )
         assertTrue(state.defaultData.isEmpty())
+    }
+
+    @Test
+    fun testExtractPlacesInfo_returnsDefaultValuesAndDoesNotCrash_when_regionname_invalidType() {
+        state.update(
+            mapOf(
+                PLACES_SHARED_STATE to mapOf(
+                    "currentpoi" to mapOf(
+                        "regionid" to "sampleRegionId",
+                        "regionname" to true
+                    )
+                )
+            )
+        )
+        assertEquals(
+            "sampleRegionId",
+            state.defaultData[AnalyticsConstants.ContextDataKeys.REGION_ID]
+        )
+        assertNull(
+            state.defaultData[AnalyticsConstants.ContextDataKeys.REGION_NAME]
+        )
+    }
+
+    @Test
+    fun testExtractPlacesInfo_returnsDefaultValuesAndDoesNotCrash_when_regionid_invalidType() {
+        state.update(
+            mapOf(
+                PLACES_SHARED_STATE to mapOf(
+                    "currentpoi" to mapOf(
+                        "regionid" to 123,
+                        "regionname" to "sampleRegionName"
+                    )
+                )
+            )
+        )
+        assertEquals(
+            "sampleRegionName",
+            state.defaultData[AnalyticsConstants.ContextDataKeys.REGION_NAME]
+        )
+        assertNull(
+            state.defaultData[AnalyticsConstants.ContextDataKeys.REGION_ID]
+        )
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes bug in Places shared state parsing where String types are assumed. The Places shared state may contain other values types, however, such as numbers, booleans, doubles, and maps. If the Places shared state contained values other than String type then the parsing failed and the Places data was not added to the Analytics hit. This PR fixes that by reading the Places shared state as type Object, then reading the individual region name and ID as Strings.

See internal bug: MOB-21198

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
