### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -39,6 +39,6 @@ jobs:
     with:
       tag: ${{ github.event.inputs.tag }}
       create-github-release: ${{ github.event.inputs.create-github-release == 'true' }}
-      version-validation-paths: code/gradle.properties, code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsConstants.kt
+      version-validation-paths: code/gradle.properties
       version-validation-dependencies: Core ${{ github.event.inputs.core-dependency }}
     secrets: inherit


### PR DESCRIPTION
The release workflow fails due to incorrect regex matching. Temporarily disabling version validation during release. 