### PR TITLE
Rename version constant and reenable release version validation

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -39,6 +39,6 @@ jobs:
     with:
       tag: ${{ github.event.inputs.tag }}
       create-github-release: ${{ github.event.inputs.create-github-release == 'true' }}
-      version-validation-paths: code/gradle.properties
+      version-validation-paths: code/gradle.properties, code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsConstants.kt
       version-validation-dependencies: Core ${{ github.event.inputs.core-dependency }}
     secrets: inherit

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsConstants.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsConstants.kt
@@ -18,7 +18,7 @@ internal object AnalyticsConstants {
 
     const val EXTENSION_NAME = "com.adobe.module.analytics"
     const val FRIENDLY_NAME = "Analytics"
-    const val EXTENSION_VERSION = "3.0.2"
+    const val VERSION = "3.0.2"
     const val DATASTORE_NAME = "AnalyticsDataStorage"
     const val DATA_QUEUE_NAME = EXTENSION_NAME
     const val REORDER_QUEUE_NAME = "com.adobe.module.analyticsreorderqueue"

--- a/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
+++ b/code/analytics/src/main/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtension.kt
@@ -83,7 +83,7 @@ internal class AnalyticsExtension : Extension {
     }
 
     override fun getVersion(): String {
-        return AnalyticsConstants.EXTENSION_VERSION
+        return AnalyticsConstants.VERSION
     }
 
     /**

--- a/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtensionVersionTest.kt
+++ b/code/analytics/src/test/java/com/adobe/marketing/mobile/analytics/internal/AnalyticsExtensionVersionTest.kt
@@ -27,7 +27,7 @@ class AnalyticsExtensionVersionTest {
 
     @Test
     fun internalExtensionVersion_publicExtensionVersion_asEqual() {
-        assertEquals(AnalyticsConstants.EXTENSION_VERSION, Analytics.extensionVersion())
+        assertEquals(AnalyticsConstants.VERSION, Analytics.extensionVersion())
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR renames the extension version variable from `EXTENSION_VERSION` -> `VERSION` to align with the regex used for `.kt` files by default for version update/validation.

It also reenables validation of the version in the constants file as part of the release workflow.

See example version job here:
* https://github.com/timkimadobe/aepsdk-analytics-android/actions/runs/13255855795
* Resulting PR: https://github.com/timkimadobe/aepsdk-analytics-android/pull/1/files

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
